### PR TITLE
fix: ensure that only string fields are passed to scratchpad

### DIFF
--- a/src/otter/task/model.py
+++ b/src/otter/task/model.py
@@ -75,6 +75,14 @@ class Spec(BaseModel, extra='allow'):
     def task_type(self, value: str) -> None:
         self.name = f'{value} {self.name.split(" ", 1)[1]}'
 
+    @classmethod
+    def templatable_fields(cls) -> set[str]:
+        """Fields that can be templated in the spec.
+
+        Returns a set of field names that can be potentially templated (string fields).
+        """
+        return {f for f, v in cls.model_fields.items() if v.annotation is str}
+
 
 class State(Enum):
     """Enumeration of possible states for a :py:class:`otter.task.model.Task`."""


### PR DESCRIPTION
# Context

I have encountered an issue when attempting to use a `Spec` that contains the non-string fields. 

The Exception is thrown by the `Template` class assuming that the `Template.template` is of unexpected type - non-string. 

In my case I wanted to have a `bool` field in the `Spec`

```python

class MySpec(Spec):

    stats_uri: str = "https://www.ebi.ac.uk/gwas/api/search/stats"

    destination_template: str = "output/{release_date}/some_file.txt"

    promote: bool = True # <-- offending field
```

The following resulted in
```
TypeError: expected string or bytes-like object, got 'bool'
```
In the details I have pasted the example code with the error I have encountered.

<summary>Exception</summary>
<details>


```
Traceback (most recent call last):
  File "/Users/ss60/Projects/gentroutils/.venv/lib/python3.13/site-packages/otter/step/model.py", line 153, in run
    self.tasks.update(self._instantiate_tasks(self._get_ready_specs()))
                      ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ss60/Projects/gentroutils/.venv/lib/python3.13/site-packages/otter/step/model.py", line 52, in _instantiate_tasks
    new_tasks = {spec.name: self.task_registry.instantiate(spec) for spec in specs}
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/ss60/Projects/gentroutils/.venv/lib/python3.13/site-packages/otter/task/task_registry.py", line 102, in instantiate
    **self.scratchpad.replace_dict(
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        spec.model_dump(),
        ^^^^^^^^^^^^^^^^^^
        ignore_missing=spec.scratchpad_ignore_missing,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/ss60/Projects/gentroutils/.venv/lib/python3.13/site-packages/otter/scratchpad/model.py", line 178, in replace_dict
    replaced_dict[key] = self._replace_any(value, ignore_missing=ignore_missing)
                         ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ss60/Projects/gentroutils/.venv/lib/python3.13/site-packages/otter/scratchpad/model.py", line 158, in _replace_any
    return self._replace(v, ignore_missing=ignore_missing)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ss60/Projects/gentroutils/.venv/lib/python3.13/site-packages/otter/scratchpad/model.py", line 128, in _replace
    return replacer.substitute(self.sentinel_dict)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/ss60/Projects/gentroutils/.venv/lib/python3.13/site-packages/otter/scratchpad/model.py", line 40, in substitute
    preserved_mapping = {k: get_or_preserve(k) for k in self.get_identifiers()}
                                                        ~~~~~~~~~~~~~~~~~~~~^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/string.py", line 159, in get_identifiers
    for mo in self.pattern.finditer(self.template):
              ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'bool'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ss60/Projects/gentroutils/.venv/bin/gentroutils", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/ss60/Projects/gentroutils/src/gentroutils/__init__.py", line 8, in main
    runner.run()
    ~~~~~~~~~~^^
  File "/Users/ss60/Projects/gentroutils/.venv/lib/python3.13/site-packages/otter/core.py", line 102, in run
    step.run()
    ~~~~~~~~^^
  File "/Users/ss60/Projects/gentroutils/.venv/lib/python3.13/site-packages/otter/step/model.py", line 176, in run
    raise StepFailedError(e)
otter.util.errors.StepFailedError: expected string or bytes-like object, got 'bool'

```
</details>


## Implementations

This PR attempts to fix the issue above with the approach to look over the `Spec` fields to find the `templatable fields` - currently with `str` type and then uses this list to filter the fields that should be passed to the Scratchpad for templating.

Other fields (non-str) are not submitted to Scratchpad resulting in no templating.


I did not add tests, but tested on my model, this approach do not result in Exception anymore.