### PR TITLE
fix: Allow pathlib.Path object in templatable fields.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opentargets-otter"
-version = "25.0.5"
+version = "25.0.6"
 description = "Open Targets Task ExcutoR"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/otter/task/model.py
+++ b/src/otter/task/model.py
@@ -75,14 +75,6 @@ class Spec(BaseModel, extra='allow'):
     def task_type(self, value: str) -> None:
         self.name = f'{value} {self.name.split(" ", 1)[1]}'
 
-    @classmethod
-    def templatable_fields(cls) -> set[str]:
-        """Fields that can be templated in the spec.
-
-        Returns a set of field names that can be potentially templated (string fields).
-        """
-        return {f for f, v in cls.model_fields.items() if v.annotation is str}
-
 
 class State(Enum):
     """Enumeration of possible states for a :py:class:`otter.task.model.Task`."""

--- a/src/otter/task/task_registry.py
+++ b/src/otter/task/task_registry.py
@@ -84,9 +84,6 @@ class TaskRegistry:
         """Instantiate a Task.
 
         Template replacement is performed here, right before initializing the Task.
-        All non-templatable fields (non-string fields) are passed as is, while
-        templatable fields (string fields) are submitted into the scratchpad for
-        potential replacement.
 
         :param spec: The spec to instantiate the Task from.
         :type spec: Spec
@@ -101,15 +98,11 @@ class TaskRegistry:
 
         try:
             spec = spec_class(**spec.model_dump())
-            templatable_fields = spec.templatable_fields()
-            templatable_spec_dump = spec.model_dump(include=templatable_fields)
-            non_templatable_spec_dump = spec.model_dump(exclude=templatable_fields)
             replaced_spec = spec_class(
                 **self.scratchpad.replace_dict(
-                    templatable_spec_dump,
+                    spec.model_dump(),
                     ignore_missing=spec.scratchpad_ignore_missing,
-                ),
-                **non_templatable_spec_dump,
+                )
             )
         except ValidationError as e:
             logger.critical(f'invalid spec for task {spec.name}')

--- a/src/test/test_scratchpad.py
+++ b/src/test/test_scratchpad.py
@@ -1,0 +1,45 @@
+"""Test scratchpad functionality."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from otter.scratchpad.model import Scratchpad
+
+
+class TestScratchpad:
+    """Test the Scratchpad model."""
+
+    @pytest.mark.parametrize(
+        ('dict_to_replace', 'expected_dict'),
+        [
+            pytest.param({'x1': 'Value ${replace}'}, {'x1': 'Value B'}, id='String replacement'),
+            pytest.param({'x1': Path('${replace}')}, {'x1': Path('B')}, id='Path replacement'),
+            pytest.param({'x1': 0.1}, {'x1': 0.1}, id='Float - no replacement'),
+            pytest.param({'x1': 123}, {'x1': 123}, id='Int - no replacement'),
+            pytest.param({'x1': True}, {'x1': True}, id='Bool - no replacement'),
+            pytest.param({'x1': None}, {'x1': None}, id='None - no replacement'),
+            pytest.param(
+                {'x1': ['Value ${replace}', 'Another ${replace}']},
+                {'x1': ['Value B', 'Another B']},
+                id='List replacement',
+            ),
+            pytest.param(
+                {'x1': {'y1': 'Value ${replace}', 'y2': 'Another ${replace}'}},
+                {'x1': {'y1': 'Value B', 'y2': 'Another B'}},
+                id='Dict replacement',
+            ),
+            pytest.param(
+                {'x1': 'Value ${replace}', 'x2': 'Another ${replace}'},
+                {'x1': 'Value B', 'x2': 'Another B'},
+                id='Multiple replacements',
+            ),
+        ],
+    )
+    def test_replace_dict(self, dict_to_replace: dict[str, Any], expected_dict: dict[str, Any]) -> None:
+        """Test replace_dict method."""
+        sp = Scratchpad()
+        sp.store('replace', 'B')
+        result = sp.replace_dict(dict_to_replace)
+        assert result == expected_dict

--- a/uv.lock
+++ b/uv.lock
@@ -439,7 +439,7 @@ wheels = [
 
 [[package]]
 name = "opentargets-otter"
-version = "25.0.5"
+version = "25.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
# Context

This PR introduces changes to the scratchpad that ensures all fields apart from  `string`, `Path` and their invariant types (list, dict) are not templated by `ScratchpadTemplate`.



The default implementation (from `v25.0.3`) of ScratchpadTemplate broke the Spec replacement when Spec fields were not in the types defined in [`Scratchpad._replace_any`](https://github.com/opentargets/otter/blob/1f07eca80c6a59ab5a4d50907d37a3e5b453c0b8/src/otter/scratchpad/model.py#L150). This lead to errors thrown when the type passed to `ScratchpadTemplate` was not a string.

In actual implementation I do not think we would ever want to replace anything apart from yaml string or their invariants, thus I added a guard that will skip the replacement when the type is not valid for replacement.


This implementation varies from the one used for `v25.0.4` as I have found it easier to do the filtering of the templatable fields directly where the replacement happens, instead of inside the `TaskRegistry`, thus the update.