### PR TITLE
fix(google): avoid forcing requester-pays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opentargets-otter"
-version = "25.0.4"
+version = "25.0.5"
 description = "Open Targets Task ExcutoR"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/otter/core.py
+++ b/src/otter/core.py
@@ -6,6 +6,7 @@ from loguru import logger
 
 from otter.config import load_config
 from otter.manifest.manifest_manager import ManifestManager
+from otter.manifest.model import Result
 from otter.scratchpad import load_scratchpad
 from otter.step.model import Step
 from otter.task import load_specs
@@ -101,3 +102,7 @@ class Runner:
         step.run()
 
         manifest.complete(step)
+
+        if manifest.manifest.result not in [Result.PENDING, Result.SUCCESS]:
+            logger.error('the run has failed')
+            raise SystemExit(1)

--- a/src/otter/step/model.py
+++ b/src/otter/step/model.py
@@ -193,7 +193,7 @@ class Step(StepReporter):
 
                     # process completed tasks
                     if futures:
-                        logger.debug(f'waiting for {len(futures)} task(s) to complete')
+                        logger.trace(f'waiting for {len(futures)} task(s) to complete')
                         done, _ = wait(futures.values(), timeout=MANAGER_POLLING_RATE, return_when='FIRST_COMPLETED')
 
                         for future in done:

--- a/src/otter/storage/google.py
+++ b/src/otter/storage/google.py
@@ -12,7 +12,7 @@ from google import auth
 from google.api_core.exceptions import GoogleAPICallError, PreconditionFailed
 from google.auth import exceptions as auth_exceptions
 from google.auth.transport.requests import AuthorizedSession
-from google.cloud import storage
+from google.cloud import storage  # type: ignore[import-untyped]
 from google.cloud.exceptions import NotFound
 from loguru import logger
 
@@ -48,7 +48,7 @@ class GoogleStorage(RemoteStorage):
         try:
             credentials: Credentials
             project_id: str
-            credentials, project_id = auth.default(scopes=GOOGLE_SCOPES)
+            credentials, project_id = auth.default(scopes=GOOGLE_SCOPES)  # pyright: ignore[reportAssignmentType, reportUnknownMemberType, reportUnknownVariableType]
             logger.debug(f'gcp authenticated on project {project_id}')
         except auth_exceptions.DefaultCredentialsError as e:
             logger.critical(f'error authenticating on gcp: {e}')
@@ -74,7 +74,7 @@ class GoogleStorage(RemoteStorage):
         if prefix is None:
             raise StorageError(f'invalid prefix: {prefix}')
         try:
-            blob = bucket.blob(prefix)
+            blob = bucket.blob(prefix)  # pyright: ignore[reportUnknownMemberType]
         except GoogleAPICallError as e:
             raise StorageError(f'error preparing blob: {e}')
         return blob
@@ -101,11 +101,11 @@ class GoogleStorage(RemoteStorage):
         :raises NotFoundError: If the file does not exist.
         """
         bucket_name, prefix = self._parse_uri(uri)
-        bucket = self.client.bucket(bucket_name, user_project=self.project_id)
+        bucket = self.client.bucket(bucket_name, user_project=self.project_id)  # pyright: ignore[reportUnknownMemberType]
         blob = self._prepare_blob(bucket, prefix)
 
         try:
-            blob.reload()
+            blob.reload()  # pyright: ignore[reportUnknownMemberType]
         except NotFound:
             raise NotFoundError(uri)
         except GoogleAPICallError as e:
@@ -125,8 +125,8 @@ class GoogleStorage(RemoteStorage):
         :raises StorageError: If the prefix is invalid.
         """
         bucket_name, prefix = self._parse_uri(uri)
-        bucket = self.client.bucket(bucket_name, user_project=self.project_id)
-        blob_names: list[str] = [n.name for n in list(bucket.list_blobs(prefix=prefix))]
+        bucket = self.client.bucket(bucket_name, user_project=self.project_id)  # pyright: ignore[reportUnknownMemberType]
+        blob_names: list[str] = [n.name for n in list(bucket.list_blobs(prefix=prefix))]  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType, reportUnknownArgumentType]
 
         # filter out blobs that have longer prefixes
         blob_name_list = [n for n in blob_names if self._is_blob_shallow(n, prefix)]
@@ -151,8 +151,8 @@ class GoogleStorage(RemoteStorage):
         :rtype: list[str]
         """
         bucket_name, glob = self._parse_uri(uri)
-        bucket = self.client.bucket(bucket_name, user_project=self.project_id)
-        blob_names: list[str] = [n.name for n in list(bucket.list_blobs(match_glob=glob))]
+        bucket = self.client.bucket(bucket_name, user_project=self.project_id)  # pyright: ignore[reportUnknownMemberType]
+        blob_names: list[str] = [n.name for n in list(bucket.list_blobs(match_glob=glob))]  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType, reportUnknownArgumentType]
 
         if len(blob_names) == 0:
             logger.warning(f'no files found matching glob {uri}')
@@ -172,11 +172,11 @@ class GoogleStorage(RemoteStorage):
         :raises StorageError: If an error occurs while downloading the file.
         """
         bucket_name, prefix = self._parse_uri(uri)
-        bucket = self.client.bucket(bucket_name, user_project=self.project_id)
+        bucket = self.client.bucket(bucket_name, user_project=self.project_id)  # pyright: ignore[reportUnknownMemberType]
         blob = self._prepare_blob(bucket, prefix)
 
         try:
-            blob.download_to_filename(dst)
+            blob.download_to_filename(dst)  # pyright: ignore[reportUnknownMemberType]
         except NotFound:
             raise NotFoundError(uri)
         except (GoogleAPICallError, OSError) as e:
@@ -194,11 +194,11 @@ class GoogleStorage(RemoteStorage):
         :rtype: tuple[str, int]
         """
         bucket_name, prefix = self._parse_uri(uri)
-        bucket = self.client.bucket(bucket_name, user_project=self.project_id)
+        bucket = self.client.bucket(bucket_name, user_project=self.project_id)  # pyright: ignore[reportUnknownMemberType]
         blob = self._prepare_blob(bucket, prefix)
 
         try:
-            blob_str = blob.download_as_string()
+            blob_str = blob.download_as_string()  # pyright: ignore[reportUnknownMemberType]
         except NotFound:
             raise NotFoundError(uri)
 
@@ -225,19 +225,19 @@ class GoogleStorage(RemoteStorage):
         :raises PreconditionFailedError: If the revision number does not match.
         """
         bucket_name, prefix = self._parse_uri(uri)
-        bucket = self.client.bucket(bucket_name, user_project=self.project_id)
+        bucket = self.client.bucket(bucket_name, user_project=self.project_id)  # pyright: ignore[reportUnknownMemberType]
         blob = self._prepare_blob(bucket, prefix)
 
         try:
             if revision is not None:
-                blob.upload_from_filename(src, if_generation_match=revision)
+                blob.upload_from_filename(src, if_generation_match=revision)  # pyright: ignore[reportUnknownMemberType]
             else:
-                blob.upload_from_filename(src)
+                blob.upload_from_filename(src)  # pyright: ignore[reportUnknownMemberType]
         except PreconditionFailed:
             raise PreconditionFailedError(f'upload of {src} failed due to generation mismatch')
         except (GoogleAPICallError, OSError) as e:
             raise StorageError(f'error uploading {src}: {e}')
-        blob.reload()
+        blob.reload()  # pyright: ignore[reportUnknownMemberType]
         return blob.generation or 0
 
     def get_session(self) -> AuthorizedSession:

--- a/src/otter/storage/model.py
+++ b/src/otter/storage/model.py
@@ -23,20 +23,6 @@ class RemoteStorage(ABC):
         """
 
     @abstractmethod
-    def check(self, uri: str) -> bool:
-        """Check if the provided storage is valid.
-
-        This method should check if the storage exists and has proper permissions.
-        On Google Cloud Storage, for example, this would check if the bucket exists
-        and the service account has get, list and create permissions.
-
-        :param uri: The URI to check.
-        :type uri: str
-        :return: True if the storage exists, False otherwise.
-        :rtype: bool
-        """
-
-    @abstractmethod
     def stat(self, uri: str) -> dict[str, Any]:
         """Get metadata for a file.
 

--- a/src/otter/storage/noop.py
+++ b/src/otter/storage/noop.py
@@ -24,10 +24,6 @@ class NoopStorage(RemoteStorage):
         """The name of the storage provider."""
         return 'No-operation storage'
 
-    def check(self, uri: str) -> bool:
-        """Check if a file exists."""
-        return False
-
     def stat(self, uri: str) -> dict[str, Any]:
         """Get metadata for a file."""
         raise NotFoundError(uri)

--- a/src/otter/util/errors.py
+++ b/src/otter/util/errors.py
@@ -42,8 +42,10 @@ class DownloadError(OtterError):
 class NotFoundError(OtterError):
     """Raise when something is not found."""
 
-    def __init__(self, msg: str | None = None) -> None:
-        super().__init__(msg)
+    def __init__(self, thing: str | None = None) -> None:
+        if thing is None:
+            thing = 'item'
+        super().__init__(f'{thing} not found')
 
 
 class PreconditionFailedError(OtterError):

--- a/src/otter/util/logger.py
+++ b/src/otter/util/logger.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import loguru
 from loguru import logger
 
-_runner_name = globals().get('__app_name__', 'otter')
+_runner_name: list[str] = ['otter']
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -46,7 +46,7 @@ def get_exception_info(record_exception: loguru.RecordException | None) -> tuple
         # go back in the stack to the first frame originated inside the app
         while tb.tb_next:
             next_name = tb.tb_next.tb_frame.f_globals.get('__name__', None)
-            if not next_name or _runner_name not in next_name:
+            if not next_name or not any(next_name.startswith(rn) for rn in _runner_name):
                 break
             name = next_name
             tb = tb.tb_next
@@ -168,8 +168,8 @@ def init_logger(log_level: str = 'INFO', app_name: str | None = None) -> None:
     :type app_name: str | None
     """
     if app_name is not None:
-        global _runner_name  # noqa: PLW0603
-        _runner_name = app_name
+        global _runner_name  # noqa: PLW0602
+        _runner_name.append(app_name)
 
     logger.remove()
     logger.add(sink=sys.stdout, level=log_level, format=get_format_log())

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -439,7 +439,7 @@ wheels = [
 
 [[package]]
 name = "opentargets-otter"
-version = "25.0.2"
+version = "25.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
## Context
In this PIS PR https://github.com/opentargets/pis/pull/151 I need to download some public access data. This fails because Otter always passes `user_project=open-targets-eu-dev` (`user_project=self.project_id`), which is unnecessary and triggers requester-pays. To load data from a public bucket, we need to read the file with default credentials.

This PR implements changes in `otter/storage/google.py`:
- `_get_bucket()` first tries without user_project, and only retries with it if needed. If bucket.reload() is forbidden, it now falls back gracefully and lets object operations decide access.
- (OBSOLETE) I relaxed `check()` to only probe read permissions (storage.objects.get/list) and to not fail when IAM tests aren’t allowed