### PR TITLE
Fix copy many destination

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opentargets-otter"
-version = "26.03.4"
+version = "26.03.5"
 description = "Open Targets Task ExcutoR"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/otter/tasks/copy_many.py
+++ b/src/otter/tasks/copy_many.py
@@ -53,7 +53,7 @@ class CopyMany(Task):
     async def _copy_single_file(self, source: str, semaphore: asyncio.Semaphore) -> Artifact:
         async with semaphore:
             filename = Path(source).name
-            dest_path = f'{self.spec.destination}/{filename}'
+            dest_path = f'{self.spec.destination.rstrip("/")}/{filename.lstrip("/")}'
 
             for attempt in range(MAX_RETRIES + 1):
                 try:


### PR DESCRIPTION
This PR fixes issue when user submits a task like:

```{yaml}
  baseline_expression:
    - name: copy_many baseline expression
      sources: gs://ot-team/tobi/baseline_expression/aggregated-new/merged/*.parquet
      destination: output/baseline_expression/
```

The **trailing slash** in destination resolves the output to `output/baseline_expression//part_*.parquet`. Which is not desired output. 


## Implementations
- [x] left trim the slash from filename
- [x] right trim the slash from destination