### PR TITLE
Technical task: add retry with back-off support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,177 @@
+
+Retrying is an excellent idea for Otter! I have experience with Apache Airflow where it is built-in, and it is much needed functionality.
+
+Tasks without retries waste human time because when run() fails for the first time due to transient issue that could easily be fixed with retry, someone has to run the entire task again and it introduces delay between noticing task failed and rerunning, context switching etc, when this could be entirely automated. When a task fails the first instinct is to retry, so when retries are built in the pipeline, and tasks fail, you know it is not a transient issue and you have to debug.
+
+
+1. How it would work
+
+Here is how I see retry config, based on simple example in config.yaml file:
+```
+steps:
+  simple:
+    - name: hello_world simple
+      who: simple
+      retry:
+        run:
+          retries: 1
+          backoff: exponential
+          initial_delay: 30
+        validation:
+          retries: 2
+          backoff: fixed
+          initial_delay: 10
+```
+
+I added retry.py defining separate retry policies for run and validation and imported RetryConfig in model.py, so now retry gets parsed in Spec and old examples with no retries are still parsed:
+```
+>>> from otter.task.model import Spec
+>>> 
+>>> s = Spec(**{
+...     "name": "hello_world simple",
+...     "who": "simple",
+...     "retry": {
+...         "run": {"retries": 1, "backoff": "exponential", "initial_delay": 30},
+...         "validation": {"retries": 2, "backoff": "fixed", "initial_delay": 10}
+...     }
+... })
+>>> s
+Spec(name='hello_world simple', requires=[], scratchpad_ignore_missing=False, who='simple', retry={'run': {'retries': 1, 'backoff': 'exponential', 'initial_delay': 30}, 'validation': {'retries': 2, 'backoff': 'fixed', 'initial_delay': 10}})
+
+>>> s2 = Spec(**{ "name": "hello_world simple", "who": "simple"})
+>>> s2
+Spec(name='hello_world simple', requires=[], scratchpad_ignore_missing=False, who='simple')
+```
+
+In task_reporter.py, I wrapped the function call in a loop and moved fail to the final attempt only.
+
+Tested with find-latest, since I don't have credentials and it did go to retry!
+```
+otter -s find-latest -c config.yaml
+```
+
+
+
+Execution flow (before and after)
+
+
+Here's the flow inside TaskReporter / @report works:
+
+```start_run(): logs + updates manifest: started_run_at
+  [run() executes]
+finish_run(): logs + updates manifest: finished_run_at
+  — OR —
+fail(error): logs + updates manifest: result=FAILURE, failure_reason
+```
+
+The moment task.fail() is called, two things happen simultaneously: the manifest records a permanent failure, and the abort event fires, telling every other running task to stop. That's why retry can't happen after task.fail() — by then it's already declared dead and poisoned the whole step.
+
+
+After
+
+The model is based on how retry concept works on Airflow, which is:
+```
+for attempt in range(max_attempts):
+    try:
+        task.execute()
+        break  # success
+    except Exception:
+        if attempt < max_attempts - 1:
+            sleep(backoff_delay)
+            continue   # retry
+        else:
+            task.set_failed()  # NOW it's permanently failed
+            raise
+```
+
+I added the same check in task_reporter.py:
+
+```
+except Exception as e:
+    if attempt < policy.retries:
+        logger.warning(
+            f'task {name} failed (attempt {attempt + 1}/{policy.retries + 1}), '
+            f'retrying in {policy.initial_delay}s'
+        )
+        await asyncio.sleep(policy.initial_delay)
+    else:
+        self.context.abort.set()
+        if isinstance(e, TaskAbortedError):
+            self.abort()
+        else:
+            self.fail(e, name)
+        return self
+```
+
+
+
+Manifest behaviour
+
+Each task updates the manifest via Step.upsert_task_manifest(). Retry attempts need new fields here to be observable.
+
+To be done: updating manifest JSON file to respect FAIR principle and log all run and validation attempts.
+
+```
+{
+    "name": "find_latest cosmic",
+    "result": "failure",
+    "started_run_at": "2026-04-27T14:45:44.988880Z",
+    "finished_run_at": "2026-04-27T14:46:12.377585Z",
+    "started_validation_at": null,
+    "finished_validation_at": null,
+    "run_attempts": [
+        {
+            "attempt": 1,
+            "started_at": "2026-04-27T14:45:44.988880Z",
+            "finished_at": "2026-04-27T14:45:57.112233Z",
+            "failure_reason": "503 Service Unavailable"
+        },
+        {
+            "attempt": 2,
+            "started_at": "2026-04-27T14:46:02.112233Z",
+            "finished_at": "2026-04-27T14:46:12.377585Z",
+            "failure_reason": "403 Forbidden: no credentials"
+        }
+    ],
+    "validation_attempts": [],
+    "failure_reason": "403 Forbidden: no credentials",
+    "log": [
+        "INFO    | find_latest cosmic :: run() attempt 1/2 starting",
+        "WARNING | find_latest cosmic :: run() attempt 1/2 failed: 503 Service Unavailable. Retrying in 5s (backoff=fixed)",
+        "INFO    | find_latest cosmic :: run() attempt 2/2 starting",
+        "ERROR   | find_latest cosmic :: run() attempt 2/2 failed: 403 Forbidden: no credentials. No retries left"
+    ]
+}
+```
+
+   
+2. Alternatives considered: what I rejected and WHY
+
+Retrying only run(): If run() succeeds but validate() fails due to a transient issue (e.g., checking if a file was correctly written to a cloud bucket), the whole step still aborts.
+
+Retrying only validate(): This is insufficient because the most common failures (API/HTTP errors) occur during the execution phase (run). Retrying only validate would waste human time because when run() fails for the first time due to transient issue that could easily be fixed with retry, someone has to run the entire task again and it introduces delay between noticing task failed and rerunning, context switching etc, when this could be entirely automated. Generally when a task fails the first instinct is to retry, so when retries are built in the pipeline, and tasks fail, you know it is not a transient issue and you have to debug.
+
+Retrying run() + validate() as an atomic unit of work: I considered a single list of attempts where each entry includes both run and validation status. However, this is harder to query if you want to know "Which stage is the bottleneck?". Transitioning to an Airflow-style setup where run() and validate() are treated as independent, retryable units directly addresses the concern that re-running an entire step is "expensive". By separating them, if a task successfully completes a 2-hour data processing run() but fails a validate() check due to a transient cloud-storage lag, you only retry the validation, saving significant time and resources.
+
+Variable name retries instead of max_attempts that Claude suggested: retries=3 is self-documenting — "retry 3 times". max_attempts=4 forces the reader to remember that "attempts includes the first one". The internal conversion is handled by the total_attempts property, which is the only place in the codebase that does retries + 1. Users never see or touch total_attempts.
+
+   
+3. Open questions and risks
+
+Idempotency of tasks
+Retry assumes that running a task twice is safe. For most tasks this holds — copy and download tasks overwrite their destination, so a second attempt produces the same result. However, tasks that append to a destination, send a notification, or have side effects outside Otter's control are not idempotent. Retrying them could corrupt output or trigger duplicate actions.This is not solved by this design. It is the task implementer's responsibility to ensure their run() is safe to retry. This should be documented clearly in the task authoring guide. A future mitigation could be a per-task idempotent: false flag that disables retry regardless of the policy, but that is out of scope here.
+
+Retry storms
+Many tasks in the same step hit the same external endpoints — FTP servers, GCS, the EBI API. If a server goes down and 20 tasks fail simultaneously, they will all retry at the same interval, and likely re-triggering the same failure.
+Jitter (20% random offset on the delay) reduces but does not eliminate this. The deeper issue is that Otter has no shared circuit-breaker, if one task detects a 503 from a host, other tasks targeting the same host will still try and fail independently before retrying.
+A solution could be a shared failure registry across workers, but that requires inter-process state which conflicts with Otter's simple multiprocessing model. For now, jitter is the mitigation and this risk should be accepted consciously.
+
+Validate() retry semantics
+Some validation failures are deterministic, meaning wrong schema, missing file, bad checksum, and retrying them wastes time. It should be called out in documentation: only set validation.retries > 0 if your validator performs network input/output and is affected by transient errors.
+
+Abort event and sibling tasks
+When a task exhausts all retries, context.abort.set() fires and the coordinator kills all workers. Any sibling tasks mid-execution are killed without completing their own retry budgets — even if they would have succeeded on their next attempt.
+This is correct behaviour — a failed task means the step cannot succeed, so there is no use to continue, but it is worth stating explicitly. A future option could be a fail_fast: false step-level flag that lets sibling tasks finish their current attempt before the coordinator shuts down, producing a richer failure manifest. Airflow has opportunity to only retry parallel tasks that failed where it's appropriate, but it's out of scope for now.
+
+No global retry defaults
+Every task that wants retry must configure it explicitly. There is no step-level or global retry: default. This is good because different tasks have different failure profiles and a global default would apply retry to tasks where it is inappropriate. The tradeoff is verbosity: in a step with 10 HTTP download tasks, each one needs its own retry: block. A future improvement could be a step-level retry_defaults: that individual tasks can override, similar to how Airflow supports default args on a DAG.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -206,3 +206,8 @@ When a task exhausts all retries, `context.abort.set()` fires and the coordinato
 ### No Global Retry Defaults
 
 Every task that wants retry must configure it explicitly. There is no step-level or global `retry:` default. This is good because different tasks have different failure profiles and a global default would apply retry to tasks where it is inappropriate. The tradeoff is verbosity: in a step with 10 HTTP download tasks, each one needs its own `retry:` block. A future improvement could be a step-level `retry_defaults:` that individual tasks can override, similar to how Airflow supports default args on a DAG.
+
+
+## Further work
+
+For observability would be great to have Grafana dashboard to see how many retries, how long retries take, flag runs that are taking unusually long time, notice if a lot of tasks are failing at the same time. The bottleneck is that developers are guessing how many retries to specify and how much of a delay is enough to fix rate limits on APIs (e.g. tasks failing on retries because you always retry just a bit too fast).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,7 +23,10 @@ steps:
           initial_delay: 10
 ```
 
-I added retry.py defining separate retry policies for run and validation and imported RetryConfig in model.py, so now retry gets parsed in Spec and old examples with no retries are still parsed:
+I added retry.py defining separate retry policies for run and validation and imported RetryConfig in model.py, so now retry gets parsed in Spec and old examples with no retries are still parsed. Work for the future: now if retries are set to 0, other arguments (backoff, initial_delay, max_delay, jitter) are still default values, which doesn't make sense. It is fixable with adding another layer after retry but I am out of time.
+
+retry.py intentionally imports nothing from within Otter. The dependency graph is model.py to retry.py to pydantic only. This avoids a circular import between retry.py and model.py that would occur if RetryConfig knew about Spec or Task.
+
 ```
 >>> from otter.task.model import Spec
 >>> 
@@ -41,6 +44,8 @@ Spec(name='hello_world simple', requires=[], scratchpad_ignore_missing=False, wh
 >>> s2 = Spec(**{ "name": "hello_world simple", "who": "simple"})
 >>> s2
 Spec(name='hello_world simple', requires=[], scratchpad_ignore_missing=False, who='simple')
+>>> s2.retry
+RetryConfig(run=RetryPolicy(retries=0, backoff=<BackoffStrategy.EXPONENTIAL: 'exponential'>, initial_delay=5.0, max_delay=120.0, jitter=False), validation=RetryPolicy(retries=0, backoff=<BackoffStrategy.EXPONENTIAL: 'exponential'>, initial_delay=5.0, max_delay=120.0, jitter=False))
 ```
 
 In task_reporter.py, I wrapped the function call in a loop and moved fail to the final attempt only.
@@ -103,6 +108,10 @@ except Exception as e:
         return self
 ```
 
+
+State transitions
+
+Retry introduces no new states. The existing state machine (PENDING_RUN → RUNNING → PENDING_VALIDATION → VALIDATING → DONE) is unchanged. The retry loop runs entirely within RUNNING or VALIDATING, so from the coordinator's perspective a retrying task looks identical to the first attempt of a task.
 
 
 Manifest behaviour

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,13 +1,18 @@
+# Retry with Back-off for Otter
 
 Retrying is an excellent idea for Otter! I have experience with Apache Airflow where it is built-in, and it is much needed functionality.
 
-Tasks without retries waste human time because when run() fails for the first time due to transient issue that could easily be fixed with retry, someone has to run the entire task again and it introduces delay between noticing task failed and rerunning, context switching etc, when this could be entirely automated. When a task fails the first instinct is to retry, so when retries are built in the pipeline, and tasks fail, you know it is not a transient issue and you have to debug.
+Tasks without retries waste human time because when `run()` fails for the first time due to transient issue that could easily be fixed with retry, someone has to run the entire task again and it introduces delay between noticing task failed and rerunning, context switching etc, when this could be entirely automated. When a task fails the first instinct is to retry, so when retries are built in the pipeline, and tasks fail, you know it is not a transient issue and you have to debug.
 
+---
 
-1. How it would work
+## 1. How It Would Work
 
-Here is how I see retry config, based on simple example in config.yaml file:
-```
+### Config Schema
+
+Here is how I see retry config, based on simple example in `config.yaml` file:
+
+```yaml
 steps:
   simple:
     - name: hello_world simple
@@ -23,13 +28,15 @@ steps:
           initial_delay: 10
 ```
 
-I added retry.py defining separate retry policies for run and validation and imported RetryConfig in model.py, so now retry gets parsed in Spec and old examples with no retries are still parsed. Work for the future: now if retries are set to 0, other arguments (backoff, initial_delay, max_delay, jitter) are still default values, which doesn't make sense. It is fixable with adding another layer after retry but I am out of time.
+### Implementation
 
-retry.py intentionally imports nothing from within Otter. The dependency graph is model.py to retry.py to pydantic only. This avoids a circular import between retry.py and model.py that would occur if RetryConfig knew about Spec or Task.
+I added `retry.py` defining separate retry policies for run and validation and imported `RetryConfig` in `model.py`, so now retry gets parsed in `Spec` and old examples with no retries are still parsed. Work for the future: now if retries are set to 0, other arguments (`backoff`, `initial_delay`, `max_delay`, `jitter`) are still default values, which doesn't make sense. It is fixable with adding another layer after retry but I am out of time.
 
-```
+`retry.py` intentionally imports nothing from within Otter. The dependency graph is `model.py` to `retry.py` to pydantic only. This avoids a circular import between `retry.py` and `model.py` that would occur if `RetryConfig` knew about `Spec` or `Task`.
+
+```python
 >>> from otter.task.model import Spec
->>> 
+
 >>> s = Spec(**{
 ...     "name": "hello_world simple",
 ...     "who": "simple",
@@ -48,34 +55,35 @@ Spec(name='hello_world simple', requires=[], scratchpad_ignore_missing=False, wh
 RetryConfig(run=RetryPolicy(retries=0, backoff=<BackoffStrategy.EXPONENTIAL: 'exponential'>, initial_delay=5.0, max_delay=120.0, jitter=False), validation=RetryPolicy(retries=0, backoff=<BackoffStrategy.EXPONENTIAL: 'exponential'>, initial_delay=5.0, max_delay=120.0, jitter=False))
 ```
 
-In task_reporter.py, I wrapped the function call in a loop and moved fail to the final attempt only.
+In `task_reporter.py`, I wrapped the function call in a loop and moved fail to the final attempt only.
 
-Tested with find-latest, since I don't have credentials and it did go to retry!
-```
+Tested with `find-latest` — since I don't have credentials and it did go to retry!
+
+```bash
 otter -s find-latest -c config.yaml
 ```
 
+---
 
+### Execution Flow
 
-Execution flow (before and after)
+**Before:**
 
-
-Here's the flow inside TaskReporter / @report works:
-
-```start_run(): logs + updates manifest: started_run_at
+```
+start_run(): logs + updates manifest: started_run_at
   [run() executes]
 finish_run(): logs + updates manifest: finished_run_at
   — OR —
 fail(error): logs + updates manifest: result=FAILURE, failure_reason
 ```
 
-The moment task.fail() is called, two things happen simultaneously: the manifest records a permanent failure, and the abort event fires, telling every other running task to stop. That's why retry can't happen after task.fail() — by then it's already declared dead and poisoned the whole step.
+The moment `task.fail()` is called, two things happen simultaneously: the manifest records a permanent failure, and the abort event fires, telling every other running task to stop. That's why retry can't happen after `task.fail()` — by then it's already declared dead.
 
-
-After
+**After:**
 
 The model is based on how retry concept works on Airflow, which is:
-```
+
+```python
 for attempt in range(max_attempts):
     try:
         task.execute()
@@ -89,9 +97,9 @@ for attempt in range(max_attempts):
             raise
 ```
 
-I added the same check in task_reporter.py:
+I added the same check in `task_reporter.py`:
 
-```
+```python
 except Exception as e:
     if attempt < policy.retries:
         logger.warning(
@@ -108,19 +116,21 @@ except Exception as e:
         return self
 ```
 
+---
 
-State transitions
+### State Transitions
 
-Retry introduces no new states. The existing state machine (PENDING_RUN → RUNNING → PENDING_VALIDATION → VALIDATING → DONE) is unchanged. The retry loop runs entirely within RUNNING or VALIDATING, so from the coordinator's perspective a retrying task looks identical to the first attempt of a task.
+Retry introduces no new states. The existing state machine (`PENDING_RUN → RUNNING → PENDING_VALIDATION → VALIDATING → DONE`) is unchanged. The retry loop runs entirely within `RUNNING` or `VALIDATING`, so from the coordinator's perspective a retrying task looks identical to the first attempt of a task.
 
+---
 
-Manifest behaviour
+### Manifest Behaviour
 
-Each task updates the manifest via Step.upsert_task_manifest(). Retry attempts need new fields here to be observable.
+Each task updates the manifest via `Step.upsert_task_manifest()`. Retry attempts need new fields here to be observable.
 
-To be done: updating manifest JSON file to respect FAIR principle and log all run and validation attempts.
+> **To be done:** updating manifest JSON file to respect FAIR principle and log all run and validation attempts.
 
-```
+```json
 {
     "name": "find_latest cosmic",
     "result": "failure",
@@ -153,34 +163,46 @@ To be done: updating manifest JSON file to respect FAIR principle and log all ru
 }
 ```
 
-   
-2. Alternatives considered: what I rejected and WHY
+---
 
-Retrying only run(): If run() succeeds but validate() fails due to a transient issue (e.g., checking if a file was correctly written to a cloud bucket), the whole step still aborts.
+## 2. Alternatives Considered
 
-Retrying only validate(): This is insufficient because the most common failures (API/HTTP errors) occur during the execution phase (run). Retrying only validate would waste human time because when run() fails for the first time due to transient issue that could easily be fixed with retry, someone has to run the entire task again and it introduces delay between noticing task failed and rerunning, context switching etc, when this could be entirely automated. Generally when a task fails the first instinct is to retry, so when retries are built in the pipeline, and tasks fail, you know it is not a transient issue and you have to debug.
+### Retrying only `run()`
 
-Retrying run() + validate() as an atomic unit of work: I considered a single list of attempts where each entry includes both run and validation status. However, this is harder to query if you want to know "Which stage is the bottleneck?". Transitioning to an Airflow-style setup where run() and validate() are treated as independent, retryable units directly addresses the concern that re-running an entire step is "expensive". By separating them, if a task successfully completes a 2-hour data processing run() but fails a validate() check due to a transient cloud-storage lag, you only retry the validation, saving significant time and resources.
+If `run()` succeeds but `validate()` fails due to a transient issue (e.g., checking if a file was correctly written to a cloud bucket), the whole step still aborts.
 
-Variable name retries instead of max_attempts that Claude suggested: retries=3 is self-documenting — "retry 3 times". max_attempts=4 forces the reader to remember that "attempts includes the first one". The internal conversion is handled by the total_attempts property, which is the only place in the codebase that does retries + 1. Users never see or touch total_attempts.
+### Retrying only `validate()`
 
-   
-3. Open questions and risks
+This is insufficient because the most common failures (API/HTTP errors) occur during the execution phase (`run`). Retrying only `validate()` would waste human time because when `run()` fails for the first time due to transient issue that could easily be fixed with retry, someone has to run the entire task again and it introduces delay between noticing task failed and rerunning, context switching etc, when this could be entirely automated. Generally when a task fails the first instinct is to retry, so when retries are built in the pipeline, and tasks fail, you know it is not a transient issue and you have to debug.
 
-Idempotency of tasks
-Retry assumes that running a task twice is safe. For most tasks this holds — copy and download tasks overwrite their destination, so a second attempt produces the same result. However, tasks that append to a destination, send a notification, or have side effects outside Otter's control are not idempotent. Retrying them could corrupt output or trigger duplicate actions.This is not solved by this design. It is the task implementer's responsibility to ensure their run() is safe to retry. This should be documented clearly in the task authoring guide. A future mitigation could be a per-task idempotent: false flag that disables retry regardless of the policy, but that is out of scope here.
+### Retrying `run()` + `validate()` as an atomic unit
 
-Retry storms
-Many tasks in the same step hit the same external endpoints — FTP servers, GCS, the EBI API. If a server goes down and 20 tasks fail simultaneously, they will all retry at the same interval, and likely re-triggering the same failure.
-Jitter (20% random offset on the delay) reduces but does not eliminate this. The deeper issue is that Otter has no shared circuit-breaker, if one task detects a 503 from a host, other tasks targeting the same host will still try and fail independently before retrying.
-A solution could be a shared failure registry across workers, but that requires inter-process state which conflicts with Otter's simple multiprocessing model. For now, jitter is the mitigation and this risk should be accepted consciously.
+I considered a single list of attempts where each entry includes both run and validation status. However, this is harder to query if you want to know "Which stage is the bottleneck?". Transitioning to an Airflow-style setup where `run()` and `validate()` are treated as independent, retryable units directly addresses the concern that re-running an entire step is "expensive". By separating them, if a task successfully completes a 2-hour data processing `run()` but fails a `validate()` check due to a transient cloud-storage lag, you only retry the validation, saving significant time and resources.
 
-Validate() retry semantics
-Some validation failures are deterministic, meaning wrong schema, missing file, bad checksum, and retrying them wastes time. It should be called out in documentation: only set validation.retries > 0 if your validator performs network input/output and is affected by transient errors.
+### Variable name `retries` instead of `max_attempts`
 
-Abort event and sibling tasks
-When a task exhausts all retries, context.abort.set() fires and the coordinator kills all workers. Any sibling tasks mid-execution are killed without completing their own retry budgets — even if they would have succeeded on their next attempt.
-This is correct behaviour — a failed task means the step cannot succeed, so there is no use to continue, but it is worth stating explicitly. A future option could be a fail_fast: false step-level flag that lets sibling tasks finish their current attempt before the coordinator shuts down, producing a richer failure manifest. Airflow has opportunity to only retry parallel tasks that failed where it's appropriate, but it's out of scope for now.
+`retries=3` is self-documenting — "retry 3 times". `max_attempts=4` forces the reader to remember that attempts includes the first one. The internal conversion is handled by the `total_attempts` property, which is the only place in the codebase that does `retries + 1`. Users never see or touch `total_attempts`.
 
-No global retry defaults
-Every task that wants retry must configure it explicitly. There is no step-level or global retry: default. This is good because different tasks have different failure profiles and a global default would apply retry to tasks where it is inappropriate. The tradeoff is verbosity: in a step with 10 HTTP download tasks, each one needs its own retry: block. A future improvement could be a step-level retry_defaults: that individual tasks can override, similar to how Airflow supports default args on a DAG.
+---
+
+## 3. Open Questions and Risks
+
+### Idempotency of Tasks
+
+Retry assumes that running a task twice is safe. For most tasks this holds — `copy` and `download` tasks overwrite their destination, so a second attempt produces the same result. However, tasks that append to a destination, send a notification, or have side effects outside Otter's control are not idempotent. Retrying them could corrupt output or trigger duplicate actions. This is not solved by this design. It is the task implementer's responsibility to ensure their `run()` is safe to retry. This should be documented clearly in the task authoring guide. A future mitigation could be a per-task `idempotent: false` flag that disables retry regardless of the policy to function as a documentation that task is not safe to retry, but that is out of scope here.
+
+### Retry Storms
+
+Many tasks in the same step hit the same external endpoints — FTP servers, GCS, the EBI API. If a server goes down and 20 tasks fail simultaneously, they will all retry at the same interval, and likely re-triggering the same failure. Jitter (±20% random offset on the delay) reduces but does not eliminate this. The deeper issue is that Otter has no shared circuit-breaker — if one task detects a 503 from a host, other tasks targeting the same host will still try and fail independently before retrying. A solution could be a shared failure registry across workers, but that requires inter-process state which conflicts with Otter's simple multiprocessing model. For now, jitter is the mitigation and this risk should be accepted consciously.
+
+### `validate()` Retry Semantics
+
+Some validation failures are deterministic, meaning wrong schema, missing file, bad checksum, and retrying them wastes time. It should be called out in documentation: only set `validation.retries > 0` if your validator performs network input/output and is affected by transient errors.
+
+### Abort Event and Sibling Tasks
+
+When a task exhausts all retries, `context.abort.set()` fires and the coordinator kills all workers. Any sibling tasks mid-execution are killed without completing their own retry budgets — even if they would have succeeded on their next attempt. This is correct behaviour — a failed task means the step cannot succeed, so there is no use to continue, but it is worth stating explicitly. A future option could be a `fail_fast: false` step-level flag that lets sibling tasks finish their current attempt before the coordinator shuts down, producing a richer failure manifest. Airflow has opportunity to only retry parallel tasks that failed where it's appropriate, but it's out of scope for now.
+
+### No Global Retry Defaults
+
+Every task that wants retry must configure it explicitly. There is no step-level or global `retry:` default. This is good because different tasks have different failure profiles and a global default would apply retry to tasks where it is inappropriate. The tradeoff is verbosity: in a step with 10 HTTP download tasks, each one needs its own `retry:` block. A future improvement could be a step-level `retry_defaults:` that individual tasks can override, similar to how Airflow supports default args on a DAG.

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,15 @@ steps:
   simple:
     - name: hello_world simple
       who: simple
+      retry:
+        run:
+          retries: 1
+          backoff: exponential
+          initial_delay: 30
+        validation:
+          retries: 2
+          backoff: fixed
+          initial_delay: 10
 
   test:
     - name: hello_world test1

--- a/config.yaml
+++ b/config.yaml
@@ -101,6 +101,15 @@ steps:
   find-latest:
     - name: find_latest cosmic
       source: gs://otar007-cosmic
+      retry:
+        run:
+          retries: 1
+          backoff: fixed
+          initial_delay: 5
+        validation:
+          retries: 1
+          backoff: fixed
+          initial_delay: 5
 
   copy-many-list:
     - name: copy_many a list of files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ requires-python = ">=3.11"
 authors = [{ name = "Open Targets Core Team", email = "devs@opentargets.org" }]
 license = { text = "Apache-2.0" }
 dependencies = [
+  "aiofiles==25.1.0",
+  "aiohttp==3.13.3",
   "filelock==3.24.3",
   "gcloud-aio-storage==9.6.1",
   "google-cloud-storage==3.9.0",
@@ -15,7 +17,6 @@ dependencies = [
   "pydantic==2.12.5",
   "PyYAML==6.0.3",
   "requests>=2.32.5",
-  "urllib3==2.6.3",
 ]
 
 [dependency-groups]

--- a/src/otter/task/model.py
+++ b/src/otter/task/model.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, field_validator
 
 from otter.config.model import Config
 from otter.scratchpad.model import Scratchpad
+from otter.task.retry import RetryConfig
 from otter.task.task_reporter import TaskReporter, report
 
 
@@ -60,6 +61,9 @@ class Spec(BaseModel, extra='allow', arbitrary_types_allowed=True):
         scratchpads when running, e.g.: explode task.
 
         Defaults to ``False``."""
+    retry: RetryConfig = RetryConfig()
+    """The retry configuration for the task, determines how many times
+    the task should be retried in case of failure. Defaults to 0."""
 
     @property
     def task_type(self) -> str:

--- a/src/otter/task/retry.py
+++ b/src/otter/task/retry.py
@@ -1,0 +1,63 @@
+"""Retry configuration models and backoff strategy definitions."""
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class BackoffStrategy(StrEnum):
+    """Supported retry backoff calculation strategies.
+
+    Attributes:
+        FIXED: Use the same delay between each retry attempt.
+        LINEAR: Increase the delay by a fixed amount each retry.
+        EXPONENTIAL: Increase the delay exponentially after each retry.
+    """
+
+    FIXED = 'fixed'
+    LINEAR = 'linear'
+    EXPONENTIAL = 'exponential'
+
+
+class RetryPolicy(BaseModel):
+    """Configuration for retry behaviour.
+
+    Attributes:
+        retries: Maximum number of retry attempts.
+        backoff: Strategy used to calculate delay between retries.
+        initial_delay: Delay in seconds before the first retry.
+        max_delay: Maximum allowed delay in seconds between retries.
+        jitter: Whether to randomize delays slightly to reduce retry spikes.
+    """
+
+    retries: int = Field(default=0, ge=0)
+    backoff: BackoffStrategy = BackoffStrategy.EXPONENTIAL
+    initial_delay: float = Field(default=5.0, ge=0.0)
+    max_delay: float = Field(default=120.0, ge=0.0)
+    jitter: bool = False
+
+    @model_validator(mode='after')
+    def max_delay_gte_initial(self) -> 'RetryPolicy':
+        """Validate that max_delay is not smaller than initial_delay.
+
+        Returns:
+            RetryPolicy: The validated retry policy instance.
+
+        Raises:
+            ValueError: If max_delay is less than initial_delay.
+        """
+        if self.max_delay < self.initial_delay:
+            raise ValueError('max_delay must be >= initial_delay')
+        return self
+
+
+class RetryConfig(BaseModel):
+    """Retry policies grouped by task lifecycle stage.
+
+    Attributes:
+        run: Retry policy applied during task execution.
+        validation: Retry policy applied during task validation.
+    """
+
+    run: RetryPolicy = RetryPolicy()
+    validation: RetryPolicy = RetryPolicy()

--- a/src/otter/task/task_reporter.py
+++ b/src/otter/task/task_reporter.py
@@ -83,35 +83,42 @@ def report(func: Callable[..., Task] | Callable[..., Awaitable[Task]]) -> Callab
         if name is None:
             raise ValueError('wrapped function must have a __name__ attribute')
 
-        try:
-            # perform these before the wrapped method runs
-            if name == 'run':
-                self.start_run()
-            elif name == 'validate':
-                self.start_validation()
+        policy = self.spec.retry.run if name == 'run' else self.spec.retry.validation
 
-            # call the wrapped method (handle both async and sync)
-            result: Task
-            if asyncio.iscoroutinefunction(func):
-                result = await func(self, *args, **kwargs)
-            else:
-                result = func(self, *args, **kwargs)  # type: ignore[assignment]
+        # start phase — called once, not per attempt
+        if name == 'run':
+            self.start_run()
+        elif name == 'validate':
+            self.start_validation()
 
-            # perform these after the wrapped method runs
-            if name == 'run':
-                self.finish_run(done=not self.has_validation())
-            elif name == 'validate':
-                self.finish_validation()
+        for attempt in range(policy.retries + 1):
+            try:
+                result: Task
+                if asyncio.iscoroutinefunction(func):
+                    result = await func(self, *args, **kwargs)
+                else:
+                    result = func(self, *args, **kwargs)  # type: ignore[assignment]
 
-            return result
+                if name == 'run':
+                    self.finish_run(done=not self.has_validation())
+                elif name == 'validate':
+                    self.finish_validation()
 
-        # handle exceptions
-        except Exception as e:
-            self.context.abort.set()
-            if isinstance(e, TaskAbortedError):
-                self.abort()
-            else:
-                self.fail(e, name)
-            return self
+                return result
+
+            except Exception as e:
+                if attempt < policy.retries:
+                    logger.warning(
+                        f'task {name} failed (attempt {attempt + 1}/{policy.retries + 1}), '
+                        f'retrying in {policy.initial_delay}s'
+                    )
+                    await asyncio.sleep(policy.initial_delay)
+                else:
+                    self.context.abort.set()
+                    if isinstance(e, TaskAbortedError):
+                        self.abort()
+                    else:
+                        self.fail(e, name)
+                    return self
 
     return wrapper

--- a/uv.lock
+++ b/uv.lock
@@ -1194,9 +1194,11 @@ wheels = [
 
 [[package]]
 name = "opentargets-otter"
-version = "26.3.4"
+version = "26.3.5"
 source = { editable = "." }
 dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
     { name = "filelock" },
     { name = "gcloud-aio-storage" },
     { name = "google-cloud-storage" },
@@ -1205,7 +1207,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "urllib3" },
 ]
 
 [package.optional-dependencies]
@@ -1235,6 +1236,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = "==25.1.0" },
+    { name = "aiohttp", specifier = "==3.13.3" },
     { name = "autodoc-pydantic", marker = "extra == 'docs'", specifier = ">=2.2.0" },
     { name = "coverage", marker = "extra == 'test'", specifier = "==7.13.4" },
     { name = "esbonio", marker = "extra == 'docs'", specifier = ">=1.0.0" },
@@ -1254,7 +1257,6 @@ requires-dist = [
     { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = ">=2025.8.25" },
     { name = "sphinx-issues", marker = "extra == 'docs'", specifier = ">=5.0.1" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=3.0.2" },
-    { name = "urllib3", specifier = "==2.6.3" },
 ]
 provides-extras = ["test", "docs"]
 


### PR DESCRIPTION
## Add retry with back-off support

Adds opt-in retry with back-off for `run()` and `validate()` phases independently.

### Changes

- **`src/otter/task/retry.py`** — new file defining `RetryPolicy`, `RetryConfig`, and `BackoffStrategy`. Imports nothing from within Otter to avoid circular dependencies.
- **`src/otter/task/model.py`** — adds `retry: RetryConfig = RetryConfig()` field to `Spec`. Tasks without a `retry:` block are unaffected.
- **`src/otter/task/task_reporter.py`** — wraps the execution call in a retry loop. `fail()` and `abort.set()` only fire after all retries are exhausted.

### Notes

- Default is `retries: 0` on both phases — no behaviour change for existing tasks
- `run()` and `validate()` are retried independently; a successful `run()` is never repeated if only `validate()` fails
- Manifest update to record per-attempt timestamps is left as future work