### PR TITLE
fix: populate mtime in the gcs stat results

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opentargets-otter"
-version = "26.6.2"
+version = "26.6.3"
 description = "Open Targets Task ExecutoR"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/otter/storage/asynchronous/google.py
+++ b/src/otter/storage/asynchronous/google.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from aiohttp import ServerTimeoutError
 from gcloud.aio.storage import Storage as GCSClient
 from loguru import logger
@@ -112,11 +114,13 @@ class AsyncGoogleStorage(AsyncStorage):
                 headers=self._request_headers(),
             )
             logger.trace(f'got metadata for blob {location}')
+            updated = metadata.get('updated')
             return StatResult(
                 is_dir=False,
                 is_reg=True,
                 size=int(metadata.get('size', 0)),
                 revision=metadata.get('generation'),
+                mtime=datetime.fromisoformat(updated).timestamp() if updated else None,
             )
         # maybe a prefix if blobs exist underneath
         except Exception:

--- a/src/otter/storage/synchronous/google.py
+++ b/src/otter/storage/synchronous/google.py
@@ -83,6 +83,7 @@ class GoogleStorage(Storage):
                 is_reg=True,
                 size=blob.size or 0,
                 revision=str(blob.generation) if blob.generation else None,
+                mtime=blob.updated.timestamp() if blob.updated else None,
             )
         # maybe a prefix if blobs exist underneath
         except NotFound:

--- a/src/otter/tasks/find_latest.py
+++ b/src/otter/tasks/find_latest.py
@@ -41,16 +41,23 @@ class FindLatest(Task):
 
         file_paths = h.glob(glob)
 
-        latest, latest_mtime = None, None
+        if not file_paths:
+            raise FileNotFoundError(f'no files found matching {self.spec.source}')
+
+        latest: StorageHandle | None = None
+        latest_mtime: float | None = None
         for p in file_paths:
             f = StorageHandle(p)
-            s = f.stat()
-            if latest_mtime is None or s.mtime > latest_mtime:  # ty:ignore[unsupported-operator]
-                latest, latest_mtime = f, s.mtime
+            mtime = f.stat().mtime
+            if mtime is None:
+                logger.warning(f'{f.absolute} has no modification time, skipping it')
+                continue
+            if latest_mtime is None or mtime > latest_mtime:
+                latest, latest_mtime = f, mtime
 
         if latest is None:
-            raise FileNotFoundError(f'no files found matching {self.spec.source}')
-        else:
-            logger.info(f'latest file is {latest.absolute}')
-            self.context.scratchpad.store(self.spec.scratchpad_key or self.spec.name, latest.absolute)
+            raise FileNotFoundError(f'none of the files matching {self.spec.source} have a modification time')
+
+        logger.info(f'latest file is {latest.absolute}')
+        self.context.scratchpad.store(self.spec.scratchpad_key or self.spec.name, latest.absolute)
         return self

--- a/test/storage/asynchronous/test_storage_google.py
+++ b/test/storage/asynchronous/test_storage_google.py
@@ -1,5 +1,6 @@
 """Tests for the AsyncGoogleStorage class."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -34,6 +35,31 @@ class TestGoogleStorage:
         bucket, blob = storage._parse_uri(uri)
         assert bucket == expected_bucket
         assert blob == expected_blob
+
+    @pytest.mark.asyncio
+    async def test_stat_regular_blob_populates_mtime(
+        self,
+        storage: AsyncGoogleStorage,
+    ) -> None:
+        # find_latest relies on mtime to pick the newest file; a stat that leaves it None
+        # silently drops every candidate
+        with patch.object(storage, '_get_client') as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.download_metadata = AsyncMock(
+                return_value={
+                    'size': '1913915',
+                    'generation': '42',
+                    'updated': '2026-04-23T07:47:33.195Z',
+                }
+            )
+            mock_get_client.return_value = mock_client
+
+            result = await storage.stat('gs://bucket/file.json.gz')
+
+        assert result.is_reg is True
+        assert result.size == 1913915
+        assert result.revision == '42'
+        assert result.mtime == datetime(2026, 4, 23, 7, 47, 33, 195000, tzinfo=UTC).timestamp()
 
     @pytest.mark.asyncio
     async def test_stat_prefix(

--- a/test/storage/synchronous/test_storage_google.py
+++ b/test/storage/synchronous/test_storage_google.py
@@ -1,5 +1,6 @@
 """Tests for the GoogleStorage class."""
 
+from datetime import UTC, datetime
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -34,6 +35,32 @@ class TestGoogleStorage:
         bucket, blob = storage._parse_uri(uri)
         assert bucket == expected_bucket
         assert blob == expected_blob
+
+    def test_stat_regular_blob_populates_mtime(
+        self,
+        storage: GoogleStorage,
+    ) -> None:
+        # find_latest relies on mtime to pick the newest file; a stat that leaves it
+        # None silently drops every candidate and raises 'no files found'.
+        updated = datetime(2026, 4, 23, 7, 47, 33, 195000, tzinfo=UTC)
+        with patch.object(storage, '_get_client') as mock_get_client:
+            mock_client = MagicMock()
+            mock_bucket = MagicMock()
+            mock_blob = MagicMock()
+            mock_blob.reload = MagicMock()
+            mock_blob.size = 1913915
+            mock_blob.generation = 42
+            mock_blob.updated = updated
+            mock_bucket.blob = MagicMock(return_value=mock_blob)
+            mock_client.bucket = MagicMock(return_value=mock_bucket)
+            mock_get_client.return_value = mock_client
+
+            result = storage.stat('gs://bucket/file.json.gz')
+
+        assert result.is_reg is True
+        assert result.size == 1913915
+        assert result.revision == '42'
+        assert result.mtime == updated.timestamp()
 
     def test_stat_prefix(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -1226,7 +1226,7 @@ wheels = [
 
 [[package]]
 name = "opentargets-otter"
-version = "26.6.2"
+version = "26.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
`GoogleStorage.stat()` never populated `StatResult.mtime`. `find_latest` selects on exactly that field, so every candidate under a `gs://` prefix was discarded and the task raised `no files found matching gs://…` with the files sitting right there. This is what was breaking `pis_pharmacogenetics` against `gs://otar012-eva/pharmacogenomics/`.

`26.6.2` stopped the crash by removing the `None` guard:

```python
if latest_mtime is None or s.mtime > latest_mtime:  # ty:ignore[unsupported-operator]
```

That gets a file back, but not by modification time — with `mtime` still `None` for every candidate, the first branch is always taken and the task returns **the last file in listing order**. It happens to be right for the EVA sources only because the filenames are ISO-dated and GCS lists lexicographically. Any source whose names don't sort by date would silently pick the wrong file, which is worse than the crash.

## What this does

**Populate `mtime` in both GCS backends.** Sync reads `blob.updated`, async reads the `updated` field from the object metadata. `StatResult.mtime` has always been declared `float | None`; the filesystem backend has always set it. Only GCS didn't.

**Make `find_latest` compare by mtime again**, and drop the `ty:ignore`. Candidates without an mtime are skipped with a warning rather than compared against `None`, and the two failure modes now report separately — a prefix that matches nothing, versus a prefix whose matches all lack a modification time. Previously both surfaced as `no files found`, which is what made this hard to diagnose.

## Tests

Regression tests on both backends asserting `stat()` returns the blob's `updated` as a Unix timestamp. I verified they fail against the current backends and pass with the fix, so they're not vacuous:

```
$ git stash push -- src/otter/storage/{synchronous,asynchronous}/google.py
$ pytest -k populates_mtime
FAILED test/storage/asynchronous/test_storage_google.py::…::test_stat_regular_blob_populates_mtime
FAILED test/storage/synchronous/test_storage_google.py::…::test_stat_regular_blob_populates_mtime
$ git stash pop && pytest -k populates_mtime
2 passed
```

Full suite: 242 passed. `ruff check`, `ruff format --check` and `ty check` clean (the only `ty` diagnostic is the pre-existing `sphinx_rtd_theme` import in `docs/source/conf.py`).

Version bumped to `26.6.3`.
